### PR TITLE
Upgrade flake8 to 3.7.9.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -52,7 +52,7 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'sphinx_rtd_theme:0.1.0=sphinx_rtd_theme:0.1.1',      // candidate for removal
     ].join(",")
     def packagesToInclude = [
-        'flake8:3.6.0',
+        'flake8:3.7.9',
         'Flask:0.12.2',
         'pbr:5.1.1',
         'pex:1.5.2',

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/FailureReasonProviderIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/FailureReasonProviderIntegrationTest.groovy
@@ -34,6 +34,14 @@ class FailureReasonProviderIntegrationTest extends Specification {
         | plugins {
         |     id 'com.linkedin.python-pex'
         | }
+        !
+        | python{
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         |
         | configurations {
         |    testProj

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/ParallelWheelsIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/ParallelWheelsIntegrationTest.groovy
@@ -45,9 +45,14 @@ class ParallelWheelsIntegrationTest extends Specification {
         | apply plugin: com.linkedin.gradle.python.plugin.WheelFirstPlugin
         | version = '1.0.0'
         | python {
-        |   pex {
-        |     fatPex = false
-        |   }
+        |     pex {
+        |         fatPex = false
+        |     }
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
         | }
         | ${ PyGradleTestBuilder.createRepoClosure() }
         """.stripMargin().stripIndent()
@@ -104,6 +109,13 @@ class ParallelWheelsIntegrationTest extends Specification {
         | apply plugin: com.linkedin.gradle.python.plugin.WheelFirstPlugin
         |
         | version = '1.0.0'
+        | python {
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         | ${ PyGradleTestBuilder.createRepoClosure() }
         """.stripMargin().stripIndent()
 

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -30,11 +30,18 @@ class PythonPluginIntegrationTest extends Specification {
     def "can build library"() {
         given:
         testProjectDir.buildFile << """
-        |plugins {
-        |    id 'com.linkedin.python'
-        |    id 'com.linkedin.python-wheel-dist'
-        |}
+        | plugins {
+        |     id 'com.linkedin.python'
+        |     id 'com.linkedin.python-wheel-dist'
+        | }
         |
+        | python {
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         |${PyGradleTestBuilder.createRepoClosure()}
         """.stripMargin().stripIndent()
 
@@ -88,24 +95,29 @@ class PythonPluginIntegrationTest extends Specification {
     def "can use external library"() {
         given:
         testProjectDir.buildFile << """
-        |plugins {
-        |    id 'com.linkedin.python'
-        |}
+        | plugins {
+        |     id 'com.linkedin.python'
+        | }
         |
-        |repositories {
-        |   pyGradlePyPi()
-        |}
+        | repositories {
+        |     pyGradlePyPi()
+        | }
         |
-        |python {
-        |   details {
-        |       virtualEnvPrompt = 'pyGradle!'
-        |   }
-        |   coverage {
-        |       run = true
-        |   }
-        |}
+        | python {
+        |     details {
+        |         virtualEnvPrompt = 'pyGradle!'
+        |     }
+        |     coverage {
+        |         run = true
+        |     }
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         |
-        |buildDir = 'build2'
+        | buildDir = 'build2'
         """.stripMargin().stripIndent()
 
         when:
@@ -157,17 +169,22 @@ class PythonPluginIntegrationTest extends Specification {
     def "test pytest and coverage failure"() {
         when:
         testProjectDir.buildFile << """
-        |plugins {
-        |    id 'com.linkedin.python'
-        |}
-        |repositories {
-        |   pyGradlePyPi()
-        |}
-        |python {
-        |   coverage {
-        |       run = true
-        |   }
-        |}
+        | plugins {
+        |     id 'com.linkedin.python'
+        | }
+        | repositories {
+        |     pyGradlePyPi()
+        | }
+        | python {
+        |     coverage {
+        |         run = true
+        |     }
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         """.stripMargin().stripIndent()
 
         testProjectDir.setupCfg.text = """

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonWebApplicationPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonWebApplicationPluginIntegrationTest.groovy
@@ -35,17 +35,22 @@ class PythonWebApplicationPluginIntegrationTest extends Specification {
     def "can build web-app"() {
         given:
         testProjectDir.buildFile << """\
-        |plugins {
-        |    id 'com.linkedin.python-web-app'
-        |}
+        | plugins {
+        |     id 'com.linkedin.python-web-app'
+        | }
         |
-        |python {
-        |  pex {
-        |    fatPex = true
-        |  }
-        |}
+        | python {
+        |     pex {
+        |        fatPex = true
+        |     }
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         |
-        |version = '1.2.3'
+        | version = '1.2.3'
         |${PyGradleTestBuilder.createRepoClosure()}
         """.stripMargin().stripIndent()
 

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/tasks/Flake8TaskIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/tasks/Flake8TaskIntegrationTest.groovy
@@ -30,10 +30,17 @@ class Flake8TaskIntegrationTest extends Specification {
     def "a passing flake8"() {
         given:
         testProjectDir.buildFile << """\
-        |plugins {
-        |    id 'com.linkedin.python'
-        |}
+        | plugins {
+        |     id 'com.linkedin.python'
+        | }
         |
+        | python {
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         |${ PyGradleTestBuilder.createRepoClosure() }
         """.stripMargin().stripIndent()
 
@@ -53,10 +60,17 @@ class Flake8TaskIntegrationTest extends Specification {
     def "a failing flake8"() {
         given:
         testProjectDir.buildFile << """\
-        |plugins {
-        |    id 'com.linkedin.python'
-        |}
+        | plugins {
+        |     id 'com.linkedin.python'
+        | }
         |
+        | python {
+        |     pipConfig = [:]
+        |     for (String command : ['install', 'wheel', 'download']) {
+        |         pipConfig.put(command, [:])
+        |         pipConfig.get(command).put('no-build-isolation', 'false')
+        |     }
+        | }
         |${ PyGradleTestBuilder.createRepoClosure() }
         """.stripMargin().stripIndent()
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -65,7 +65,7 @@ class PythonExtension {
 
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
-        'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '3.6.0'],
+        'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '3.7.9'],
         'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.5.2'],
         'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '18.1'],
         'pytest'        : ['group': 'pypi', 'name': 'pytest', 'version': '3.10.0'],


### PR DESCRIPTION
Have to use no-build-isolation option for pip on a few integration tests
because flake8-3.7.x depends on entrypoints that require flit in a
build_system section of the toml file. We don't need that since we
already have a package with flit-built setup.py. In future release of
flake8 entrypoints are replaced with importlib-metadata, so this
dependency will not cause us issues any more, but the no-build-isolation
setting should be fine in the tests even in that case.